### PR TITLE
Add missing callback for fs.unlink

### DIFF
--- a/server.js
+++ b/server.js
@@ -67,7 +67,7 @@ server.on('error', function(err) {
 		})
 		testSocket.on('error', function(err) {
 			if (err.code == 'ECONNREFUSED') {
-				fs.unlink(addr)
+				fs.unlink(addr, (err) => err && console.log(err))
 				self.listen(addr)
 			} else {
 				console.log('unixsocket: Socket error ', err)


### PR DESCRIPTION
With the latest nodejs version it's required to provide a callback for the fs.unklink() function.