### PR TITLE
Dovecot passdb lookup argument changed

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,7 +33,7 @@ var server = net.createServer(function(conn) {
 				break
 			}
 			if(args[1] == 'passdb') {
-				client.hget(config.hkey_prefix + args[2], config.key, function(err, reply) {
+				client.hget(config.hkey_prefix + args[2].split(/\s+/)[0], config.key, function(err, reply) {
 					if(err) {
 						conn.write('F\n')
 						return


### PR DESCRIPTION
The argument looks like two times the same email address (username), because it uses the key and the user. Based on that the lookup need to changed for the redis hget.

Reference:
  https://doc.dovecot.org/configuration_manual/authentication/dict/