### PR TITLE
Use user argument for passdb dict lookup

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,18 +22,19 @@ var server = net.createServer(function(conn) {
 	carrier.carry(conn, function parser(line) {
 		var cmd  = line[0]
 		var args = line.slice(1)
+		var [key, user] = args.split('\t')
 
 		switch(cmd) {
 		case 'H': // Hello
 			break
 		case 'L': // Lookup
-			args = args.split('/')
-			if(args.length < 3) {
+			key = key.split('/')
+			if(key.length < 3) {
 				conn.write('F\n')
 				break
 			}
-			if(args[1] == 'passdb') {
-				client.hget(config.hkey_prefix + args[2], config.key, function(err, reply) {
+			if(key[1] == 'passdb') {
+				client.hget(config.hkey_prefix + user, config.key, function(err, reply) {
 					if(err) {
 						conn.write('F\n')
 						return


### PR DESCRIPTION
Based on the changes from dovecot it's required to handle the dict arguments correctly. The provided arguments contains the key and username seperated by tab. The key seperation is specified via `password_key` and is `passdb/%u` in core-mbox.

The example code (in perl) contains a split into key and user. We should use the user for the authentication against redis so the value of `password_key` could be changed to `passdb` without any variable information in the key.

References:
 https://doc.dovecot.org/configuration_manual/authentication/dict/